### PR TITLE
refactor: Minor clean ups in unit-tests

### DIFF
--- a/grpc/execution/server_test.go
+++ b/grpc/execution/server_test.go
@@ -324,6 +324,8 @@ func TestExecutionServiceServerV1Alpha2_ExecuteBlock(t *testing.T) {
 			if tt.expectedReturnCode > 0 {
 				require.NotNil(t, err, "ExecuteBlock should return an error")
 				require.Equal(t, tt.expectedReturnCode, status.Code(err), "ExecuteBlock failed")
+			} else {
+				require.Nil(t, err, "ExecuteBlock should not return an error")
 			}
 			if err == nil {
 				require.NotNil(t, executeBlockRes, "ExecuteBlock response is nil")

--- a/grpc/execution/test_utils.go
+++ b/grpc/execution/test_utils.go
@@ -86,7 +86,7 @@ func generateMergeChain(n int, merged bool) (*core.Genesis, []*types.Block, stri
 
 	genesis := &core.Genesis{
 		Config: &config,
-		Alloc: core.GenesisAlloc{
+		Alloc: types.GenesisAlloc{
 			testAddr: {Balance: testBalance},
 		},
 		ExtraData:  []byte("test genesis"),


### PR DESCRIPTION
The PR contains the following changes:

1. The unit-tests of the Execution API hard codes the `status.Ok` success code as 0. It is more readable to use the enum `status.Ok`
2. Add assertions for the returned error being nil, if the expected status code is not `status.Ok` to make the unit-tests stronger. 
3. Remove some un-used code.