### PR TITLE
feat: Keep track of next fee recipient in a shareable container

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/eth/catalyst"
+	"github.com/ethereum/go-ethereum/grpc"
 	"os"
 	"reflect"
 	"runtime"
@@ -206,7 +207,8 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 
 	// Configure gRPC if requested.
 	if ctx.IsSet(utils.GRPCEnabledFlag.Name) {
-		serviceV1a2, err := execution.NewExecutionServiceServerV1Alpha2(eth)
+		feeRecipientContainer := grpc.NewFeeRecipientContainer()
+		serviceV1a2, err := execution.NewExecutionServiceServerV1Alpha2(eth, &feeRecipientContainer)
 		if err != nil {
 			utils.Fatalf("failed to create execution service: %v", err)
 		}

--- a/grpc/execution/test_utils.go
+++ b/grpc/execution/test_utils.go
@@ -2,6 +2,7 @@ package execution
 
 import (
 	"crypto/ecdsa"
+	"github.com/ethereum/go-ethereum/grpc"
 	"math/big"
 	"testing"
 	"time"
@@ -134,11 +135,12 @@ func setupExecutionService(t *testing.T, noOfBlocksToGenerate int) (*eth.Ethereu
 	genesis, blocks, bridgeAddress, feeCollectorKey := generateMergeChain(noOfBlocksToGenerate, true)
 	ethservice := startEthService(t, genesis)
 
-	serviceV1Alpha1, err := NewExecutionServiceServerV1Alpha2(ethservice)
+	feeRecipientContainer := grpc.NewFeeRecipientContainer()
+	serviceV1Alpha1, err := NewExecutionServiceServerV1Alpha2(ethservice, &feeRecipientContainer)
 	require.Nil(t, err, "can't create execution service")
 
 	feeCollector := crypto.PubkeyToAddress(feeCollectorKey.PublicKey)
-	require.Equal(t, feeCollector, serviceV1Alpha1.nextFeeRecipient, "nextFeeRecipient not set correctly")
+	require.Equal(t, feeCollector, serviceV1Alpha1.feeRecipientContainer.GetNextFeeRecipient(), "feeRecipientContainer not set correctly")
 
 	bridgeAsset := genesis.Config.AstriaBridgeAddressConfigs[0].AssetDenom
 	_, ok := serviceV1Alpha1.bridgeAllowedAssets[bridgeAsset]

--- a/grpc/fee_recipient_container.go
+++ b/grpc/fee_recipient_container.go
@@ -1,0 +1,30 @@
+package grpc
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"sync"
+)
+
+type FeeRecipientContainer struct {
+	mu               *sync.RWMutex
+	nextFeeRecipient common.Address
+}
+
+func NewFeeRecipientContainer() FeeRecipientContainer {
+	return FeeRecipientContainer{
+		mu:               &sync.RWMutex{},
+		nextFeeRecipient: common.Address{},
+	}
+}
+
+func (frc *FeeRecipientContainer) GetNextFeeRecipient() common.Address {
+	frc.mu.RLock()
+	defer frc.mu.RUnlock()
+	return frc.nextFeeRecipient
+}
+
+func (frc *FeeRecipientContainer) SetNextFeeRecipient(nextFeeRecipient common.Address) {
+	frc.mu.Lock()
+	defer frc.mu.Unlock()
+	frc.nextFeeRecipient = nextFeeRecipient
+}


### PR DESCRIPTION
In the upcoming PRs, we will be implementing the `[StreamOptimisticExecutionService](https://buf.build/astria/execution-apis/file/1519/merge:astria/bundle/v1alpha1/bundle.proto#L56)` which receives a block from auctioneer and maintains a separate optimistic fork of that block. 

To execute the optimistic block, we require to read the current fee recipient from the `[ExecutionServiceServer](https://github.com/astriaorg/flame/blob/main/grpc/execution/server.go#L53)`.

To make the code more cleaner, this PR moves handling the fee recipient to a separate sharable container.

Changes made:
1. Create `FeeRecipientContainer` which contains the fee recipient and a RW lock to it
2. Add a setter and getter to set/get the fee recipient.
3. Pass the `FeeRecipientContainer` as a parameter to `NewExecutionServiceServerV1Alpha2`  