### PR TITLE
fix: Trusted Auctioneer: Address review feedback from onsite

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -341,8 +341,6 @@ func (p *BlobPool) AstriaExcludedFromBlock() *types.Transactions    { return &ty
 func (p *BlobPool) AstriaOrdered() *types.Transactions              { return &types.Transactions{} }
 func (p *BlobPool) ValidateTx(tx *types.Transaction) error          { return nil }
 
-func (p *BlobPool) ValidateTx(tx *types.Transaction) error { return nil }
-
 // Filter returns whether the given transaction can be consumed by the blob pool.
 func (p *BlobPool) Filter(tx *types.Transaction) bool {
 	return tx.Type() == types.BlobTxType


### PR DESCRIPTION
This PR addresses the following points:
1. Make `currentOptimisticSequencerBlock` an atomic pointer
2. Reduce time out for mempool clearance to 0.5s from 10s.
3. Validate txs before building a payload with them in optimistically executing them