### PR TITLE
Update docker build workflows to use new depot tokens

### DIFF
--- a/.github/workflows/astria-build-and-publish-image.yml
+++ b/.github/workflows/astria-build-and-publish-image.yml
@@ -53,7 +53,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/astriaorg/astria-geth
+            ghcr.io/astriaorg/flame
           tags: |
             type=ref,event=pr
             type=match,pattern=v(.*),group=1
@@ -72,4 +72,4 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          project: 1k5kkqpmfp
+          project: w2d6w0spqz


### PR DESCRIPTION
Update docker build workflows to use the new depot token