### PR TITLE
fix: Auctioneer: multiply effective tip with gas used by tx while streaming bid

### DIFF
--- a/grpc/optimistic/server.go
+++ b/grpc/optimistic/server.go
@@ -73,7 +73,9 @@ func (o *OptimisticServiceV1Alpha1) GetBidStream(_ *optimsticPb.GetBidStreamRequ
 
 				totalCost := big.NewInt(0)
 				effectiveTip := cmath.BigMin(pendingTx.GasTipCap(), new(big.Int).Sub(pendingTx.GasFeeCap(), optimisticBlock.BaseFee))
-				totalCost.Add(totalCost, effectiveTip)
+				gasUsed := pendingTx.Gas()
+				totalTipFee := big.NewInt(0).Mul(effectiveTip, big.NewInt(int64(gasUsed)))
+				totalCost.Add(totalCost, totalTipFee)
 
 				marshalledTxs := [][]byte{}
 				marshalledTx, err := pendingTx.MarshalBinary()
@@ -169,7 +171,7 @@ func (o *OptimisticServiceV1Alpha1) ExecuteOptimisticBlockStream(stream optimist
 
 func (o *OptimisticServiceV1Alpha1) ExecuteOptimisticBlock(ctx context.Context, req *optimsticPb.BaseBlock) (*astriaPb.Block, error) {
 	// we need to execute the optimistic block
-	log.Debug("ExecuteOptimisticBlock called", "timestamp", req.Timestamp, "sequencer_block_hash", req.SequencerBlockHash)
+	log.Debug("ExecuteOptimisticBlock called", "timestamp", req.Timestamp, "sequencer_block_hash", common.BytesToHash(req.SequencerBlockHash).String())
 
 	// Deliberately called after lock, to more directly measure the time spent executing
 	executionStart := time.Now()

--- a/grpc/optimistic/server.go
+++ b/grpc/optimistic/server.go
@@ -73,9 +73,7 @@ func (o *OptimisticServiceV1Alpha1) GetBidStream(_ *optimsticPb.GetBidStreamRequ
 
 				totalCost := big.NewInt(0)
 				effectiveTip := cmath.BigMin(pendingTx.GasTipCap(), new(big.Int).Sub(pendingTx.GasFeeCap(), optimisticBlock.BaseFee))
-				gasUsed := pendingTx.Gas()
-				totalTipFee := big.NewInt(0).Mul(effectiveTip, big.NewInt(int64(gasUsed)))
-				totalCost.Add(totalCost, totalTipFee)
+				totalCost = totalCost.Mul(effectiveTip, big.NewInt(int64(pendingTx.Gas())))
 
 				marshalledTxs := [][]byte{}
 				marshalledTx, err := pendingTx.MarshalBinary()


### PR DESCRIPTION
When we stream a bid, we also send the tip fee of the bid. Currently we were sending the `effective tip per gas`. We should be multiplying it with the gas used by the tx. 

This PR also includes a minor cosmetic change where we display the sequencer hash in the debug log called at the start of the `ExecuteOptimisticBlock` as a `common.Hash` rather than a byte array.