### PR TITLE
feat: disable txpool and filter apis when running in auctioneer mode

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2014,10 +2014,13 @@ func RegisterFilterAPI(stack *node.Node, backend ethapi.Backend, ethcfg *ethconf
 	filterSystem := filters.NewFilterSystem(backend, filters.Config{
 		LogCacheSize: ethcfg.FilterLogCacheSize,
 	})
-	stack.RegisterAPIs([]rpc.API{{
-		Namespace: "eth",
-		Service:   filters.NewFilterAPI(filterSystem),
-	}})
+
+	if !stack.AuctioneerEnabled() {
+		stack.RegisterAPIs([]rpc.API{{
+			Namespace: "eth",
+			Service:   filters.NewFilterAPI(filterSystem),
+		}})
+	}
 	return filterSystem
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -64,6 +64,10 @@ func (b *EthAPIBackend) SetHead(number uint64) {
 	b.eth.blockchain.SetHead(number)
 }
 
+func (b *EthAPIBackend) AuctioneerEnabled() bool {
+	return b.eth.AuctioneerEnabled()
+}
+
 func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	// Pending block is only known by the miner
 	if number == rpc.PendingBlockNumber {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -96,6 +96,8 @@ type Ethereum struct {
 	lock sync.RWMutex // Protects the variadic fields (e.g. gas price and etherbase)
 
 	shutdownTracker *shutdowncheck.ShutdownTracker // Tracks if and when the node has shutdown ungracefully
+
+	auctioneerEnabled bool
 }
 
 // New creates a new Ethereum object (including the initialisation of the common Ethereum object),
@@ -164,6 +166,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		bloomIndexer:      core.NewBloomIndexer(chainDb, params.BloomBitsBlocks, params.BloomConfirms),
 		p2pServer:         stack.Server(),
 		shutdownTracker:   shutdowncheck.NewShutdownTracker(chainDb),
+		auctioneerEnabled: stack.AuctioneerEnabled(),
 	}
 	bcVersion := rawdb.ReadDatabaseVersion(chainDb)
 	var dbVer = "<nil>"
@@ -342,6 +345,7 @@ func (s *Ethereum) Synced() bool                       { return s.handler.synced
 func (s *Ethereum) SetSynced()                         { s.handler.enableSyncedFeatures() }
 func (s *Ethereum) ArchiveMode() bool                  { return s.config.NoPruning }
 func (s *Ethereum) BloomIndexer() *core.ChainIndexer   { return s.bloomIndexer }
+func (s *Ethereum) AuctioneerEnabled() bool            { return s.auctioneerEnabled }
 
 // Protocols returns all the currently configured
 // network protocols to start.

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -61,6 +61,7 @@ type Backend interface {
 	GetBody(ctx context.Context, hash common.Hash, number rpc.BlockNumber) (*types.Body, error)
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
 	GetLogs(ctx context.Context, blockHash common.Hash, number uint64) ([][]*types.Log, error)
+	AuctioneerEnabled() bool
 
 	CurrentHeader() *types.Header
 	ChainConfig() *params.ChainConfig

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -53,6 +53,9 @@ type testBackend struct {
 func (b *testBackend) ChainConfig() *params.ChainConfig {
 	return params.TestChainConfig
 }
+func (b *testBackend) AuctioneerEnabled() bool {
+	return false
+}
 
 func (b *testBackend) CurrentHeader() *types.Header {
 	hdr, _ := b.HeaderByNumber(context.TODO(), rpc.LatestBlockNumber)

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -465,6 +465,12 @@ func (b *testBackend) setPendingBlock(block *types.Block) {
 	b.pending = block
 }
 
+func (b testBackend) AuctioneerEnabled() bool {
+	// TODO - we should be able to write api tests considering whether auctioneer is enabled or not.
+	// this will be necessary as we add json-rpc methods specific to auctioneer
+	return false
+}
+
 func (b testBackend) SyncProgress() ethereum.SyncProgress { return ethereum.SyncProgress{} }
 func (b testBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(0), nil

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -315,6 +315,9 @@ func (b *backendMock) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(42), nil
 }
 func (b *backendMock) BlobBaseFee(ctx context.Context) *big.Int { return big.NewInt(42) }
+func (b *backendMock) AuctioneerEnabled() bool {
+	return false
+}
 
 func (b *backendMock) CurrentHeader() *types.Header     { return b.current }
 func (b *backendMock) ChainConfig() *params.ChainConfig { return b.config }


### PR DESCRIPTION
When we are running the flame rollup in auctioneer mode, we do not want searchers to be able to peek in the auctioneer flame node mempool to look at other searchers transactions which can impact their bidding strategies. 

Closes: https://github.com/astriaorg/flame/issues/38