### PR TITLE
feat: disallow searchers from sending txs when soft block height is greater than optimistic block height

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -50,6 +50,10 @@ type EthAPIBackend struct {
 	gpo                 *gasprice.Oracle
 }
 
+func (b *EthAPIBackend) AuctioneerEnabled() bool {
+	return b.eth.AuctioneerEnabled()
+}
+
 // ChainConfig returns the active chain configuration.
 func (b *EthAPIBackend) ChainConfig() *params.ChainConfig {
 	return b.eth.blockchain.Config()

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -96,6 +96,8 @@ type Ethereum struct {
 	lock sync.RWMutex // Protects the variadic fields (e.g. gas price and etherbase)
 
 	shutdownTracker *shutdowncheck.ShutdownTracker // Tracks if and when the node has shutdown ungracefully
+
+	auctioneerEnabled bool
 }
 
 // New creates a new Ethereum object (including the initialisation of the common Ethereum object),
@@ -164,6 +166,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		bloomIndexer:      core.NewBloomIndexer(chainDb, params.BloomBitsBlocks, params.BloomConfirms),
 		p2pServer:         stack.Server(),
 		shutdownTracker:   shutdowncheck.NewShutdownTracker(chainDb),
+		auctioneerEnabled: stack.AuctioneerEnabled(),
 	}
 	bcVersion := rawdb.ReadDatabaseVersion(chainDb)
 	var dbVer = "<nil>"
@@ -330,6 +333,9 @@ func (s *Ethereum) ResetWithGenesisBlock(gb *types.Block) {
 
 func (s *Ethereum) Miner() *miner.Miner { return s.miner }
 
+func (s *Ethereum) AuctioneerEnabled() bool {
+	return s.auctioneerEnabled
+}
 func (s *Ethereum) AccountManager() *accounts.Manager  { return s.accountManager }
 func (s *Ethereum) BlockChain() *core.BlockChain       { return s.blockchain }
 func (s *Ethereum) TxPool() *txpool.TxPool             { return s.txPool }

--- a/grpc/shared/container.go
+++ b/grpc/shared/container.go
@@ -190,50 +190,6 @@ func (s *SharedServiceContainer) UnbundleRollupDataTransactions(txs []*sequencer
 			}
 			processedTxs = append(processedTxs, ethtx)
 		}
-
-		//if deposit := tx.GetDeposit(); deposit != nil {
-		//	depositTx, err := validateAndUnmarshalDepositTx(deposit, height, s.BridgeAddresses(), s.BridgeAllowedAssets())
-		//	if err != nil {
-		//		log.Error("failed to validate and unmarshal deposit tx", "error", err)
-		//		continue
-		//	}
-		//
-		//	processedTxs = append(processedTxs, depositTx)
-		//} else {
-		//	sequenceData := tx.GetSequencedData()
-		//
-		//	if !foundAllocation && height >= s.AuctioneerStartHeight() {
-		//		// check if sequence data is of type Allocation.
-		//		// we should expect only one valid allocation per block. duplicate allocations should be ignored.
-		//		allocation := &auctionv1alpha1.Allocation{}
-		//		err := proto.Unmarshal(sequenceData, allocation)
-		//		if err == nil {
-		//			unmarshalledAllocationTxs, err := unmarshalAllocationTxs(allocation, prevBlockHash, s.AuctioneerAddress(), s.Bc().Config().AstriaSequencerAddressPrefix)
-		//			if err != nil {
-		//				log.Error("failed to unmarshall allocation transactions", "error", err)
-		//				continue
-		//			}
-		//
-		//			// we found the valid allocation, we should ignore any other allocations in this block
-		//			allocationTxs = unmarshalledAllocationTxs
-		//			foundAllocation = true
-		//		} else {
-		//			ethtx, err := validateAndUnmarshalSequenceAction(tx)
-		//			if err != nil {
-		//				log.Error("failed to unmarshall sequence action", "error", err)
-		//				continue
-		//			}
-		//			processedTxs = append(processedTxs, ethtx)
-		//		}
-		//	} else {
-		//		ethtx, err := validateAndUnmarshalSequenceAction(tx)
-		//		if err != nil {
-		//			log.Error("failed to unmarshall sequence action", "error", err)
-		//			continue
-		//		}
-		//		processedTxs = append(processedTxs, ethtx)
-		//	}
-		//}
 	}
 
 	// prepend allocation txs to processedTxs

--- a/grpc/shared/container.go
+++ b/grpc/shared/container.go
@@ -190,6 +190,50 @@ func (s *SharedServiceContainer) UnbundleRollupDataTransactions(txs []*sequencer
 			}
 			processedTxs = append(processedTxs, ethtx)
 		}
+
+		//if deposit := tx.GetDeposit(); deposit != nil {
+		//	depositTx, err := validateAndUnmarshalDepositTx(deposit, height, s.BridgeAddresses(), s.BridgeAllowedAssets())
+		//	if err != nil {
+		//		log.Error("failed to validate and unmarshal deposit tx", "error", err)
+		//		continue
+		//	}
+		//
+		//	processedTxs = append(processedTxs, depositTx)
+		//} else {
+		//	sequenceData := tx.GetSequencedData()
+		//
+		//	if !foundAllocation && height >= s.AuctioneerStartHeight() {
+		//		// check if sequence data is of type Allocation.
+		//		// we should expect only one valid allocation per block. duplicate allocations should be ignored.
+		//		allocation := &auctionv1alpha1.Allocation{}
+		//		err := proto.Unmarshal(sequenceData, allocation)
+		//		if err == nil {
+		//			unmarshalledAllocationTxs, err := unmarshalAllocationTxs(allocation, prevBlockHash, s.AuctioneerAddress(), s.Bc().Config().AstriaSequencerAddressPrefix)
+		//			if err != nil {
+		//				log.Error("failed to unmarshall allocation transactions", "error", err)
+		//				continue
+		//			}
+		//
+		//			// we found the valid allocation, we should ignore any other allocations in this block
+		//			allocationTxs = unmarshalledAllocationTxs
+		//			foundAllocation = true
+		//		} else {
+		//			ethtx, err := validateAndUnmarshalSequenceAction(tx)
+		//			if err != nil {
+		//				log.Error("failed to unmarshall sequence action", "error", err)
+		//				continue
+		//			}
+		//			processedTxs = append(processedTxs, ethtx)
+		//		}
+		//	} else {
+		//		ethtx, err := validateAndUnmarshalSequenceAction(tx)
+		//		if err != nil {
+		//			log.Error("failed to unmarshall sequence action", "error", err)
+		//			continue
+		//		}
+		//		processedTxs = append(processedTxs, ethtx)
+		//	}
+		//}
 	}
 
 	// prepend allocation txs to processedTxs

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1760,7 +1760,6 @@ func (s *TransactionAPI) sign(addr common.Address, tx *types.Transaction) (*type
 
 // SubmitTransaction is a helper function that submits tx to txPool and logs a message.
 func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (common.Hash, error) {
-	log.Info("BHARATH: In send tx!", "auctioneerEnabled", b.AuctioneerEnabled())
 	// if we are running the flame node in auctioneer mode. we need to reject transactions being sent if the optimistic block
 	// height deviates from the soft block height by more than 1 block. The optimistic block is either one block ahead of the
 	// soft block or is at the same height as that of the soft block.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1779,7 +1779,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 		// it is enough to check if the soft block height is more than the optimistic block height as a condition to detect issues with
 		// optimistic block execution. We take the below conditions to understand why:
 		// can we have optimistic_block.height > soft block.height? Optimistic block can only be greater than soft block by 1 block at any given point.
-		// this is because the optimistic block is always built on top of the current parent block. This case can never happen
+		// this is because the optimistic block is always built on top of the current soft block. This case can never happen
 		// can we have optimistic_block.height == soft_block.height? This happens when conductor executes the soft block after auctioneer successfully
 		// executes the optimistic block. It is a scenario we expect to happen.
 		// can we have optimistic_block.height < soft_block.height. This should never happen. This can happen when optimistic block execution

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -59,7 +59,7 @@ const estimateGasErrorRatio = 0.015
 
 var errBlobTxNotSupported = errors.New("blob transactions not supported")
 var errDepositTxNotSupported = errors.New("deposit transactions not supported")
-var errOptimisticBlockBehind = errors.New("optimistic block production is behind. tx sending will be enabled once optimistic block production resumes")
+var errOptimisticBlockBehind = errors.New("optimistic block not in sync")
 
 // EthereumAPI provides an API to access Ethereum related information.
 type EthereumAPI struct {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -472,6 +472,11 @@ func (b testBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 func (b testBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []*big.Int, []float64, error) {
 	return nil, nil, nil, nil, nil, nil, nil
 }
+
+func (b testBackend) AuctioneerEnabled() bool {
+	// TODO - it would be good to be able to set this value for tests for the future as we build more complex functionality for auctioneer.
+	return false
+}
 func (b testBackend) BlobBaseFee(ctx context.Context) *big.Int { return new(big.Int) }
 func (b testBackend) ChainDb() ethdb.Database                  { return b.db }
 func (b testBackend) AccountManager() *accounts.Manager        { return b.accman }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -97,6 +97,7 @@ type Backend interface {
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription
 	BloomStatus() (uint64, uint64)
 	ServiceFilter(ctx context.Context, session *bloombits.MatcherSession)
+	AuctioneerEnabled() bool
 }
 
 func GetAPIs(apiBackend Backend) []rpc.API {

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -311,6 +311,7 @@ func (b *backendMock) setFork(fork string) error {
 	return nil
 }
 
+func (b *backendMock) AuctioneerEnabled() bool { return false }
 func (b *backendMock) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	return big.NewInt(42), nil
 }


### PR DESCRIPTION
If there are any issues with auctioneer or the optimistic sequencer node, optimistic blocks won't be sent to the auctioneer flame node. When optimistic blocks are not sent to the flame node, the block on whose state the mempool does stateful tx validation is not updated. This leads to searchers tx being validated on old state which is undesirable. 
When there is an issue with optimistic block production, we do not want searchers to be able to submit txs.

Closes: https://github.com/astriaorg/flame/issues/39