### PR TITLE
chore(geth): disable filter apis for auctioneer node

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2013,10 +2013,12 @@ func RegisterFilterAPI(stack *node.Node, backend ethapi.Backend, ethcfg *ethconf
 	filterSystem := filters.NewFilterSystem(backend, filters.Config{
 		LogCacheSize: ethcfg.FilterLogCacheSize,
 	})
-	stack.RegisterAPIs([]rpc.API{{
-		Namespace: "eth",
-		Service:   filters.NewFilterAPI(filterSystem),
-	}})
+	if !stack.AuctioneerEnabled() {
+		stack.RegisterAPIs([]rpc.API{{
+			Namespace: "eth",
+			Service:   filters.NewFilterAPI(filterSystem),
+		}})
+	}
 	return filterSystem
 }
 


### PR DESCRIPTION
Disable filter apis for auctioneer flame node. Using [`eth_newPendingTransactionsFilter`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newpendingtransactionfilter) searchers can peek into the public mempool for information on competition.