### PR TITLE
chore(grpc): use EffectiveGasTip method to get the tip of a tx while streaming bids

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -372,6 +372,7 @@ func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
 	if gasFeeCap.Cmp(baseFee) == -1 {
 		err = ErrGasFeeCapTooLow
 	}
+
 	return math.BigMin(tx.GasTipCap(), gasFeeCap.Sub(gasFeeCap, baseFee)), err
 }
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -372,7 +372,6 @@ func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
 	if gasFeeCap.Cmp(baseFee) == -1 {
 		err = ErrGasFeeCapTooLow
 	}
-
 	return math.BigMin(tx.GasTipCap(), gasFeeCap.Sub(gasFeeCap, baseFee)), err
 }
 

--- a/grpc/optimistic/server.go
+++ b/grpc/optimistic/server.go
@@ -75,10 +75,10 @@ func (o *AuctionServiceV1Alpha1) GetBidStream(_ *auctionPb.GetBidStreamRequest, 
 
 				totalCost := big.NewInt(0)
 				effectiveTip, err := pendingTx.EffectiveGasTip(optimisticBlock.BaseFee)
+				// don't throw an error but we should avoid streaming this bid
 				if err != nil {
 					txsTipTooLow.Inc(1)
 					log.Debug("effective tip is too low", "effectiveTip", effectiveTip.String())
-					// don't throw an error but we should avoid streaming this bid
 					continue
 				}
 				totalCost = totalCost.Mul(effectiveTip, big.NewInt(int64(pendingTx.Gas())))

--- a/grpc/optimistic/server.go
+++ b/grpc/optimistic/server.go
@@ -75,7 +75,7 @@ func (o *AuctionServiceV1Alpha1) GetBidStream(_ *auctionPb.GetBidStreamRequest, 
 				totalCost := big.NewInt(0)
 				effectiveTip, err := pendingTx.EffectiveGasTip(optimisticBlock.BaseFee)
 				if err != nil {
-					log.Error("effective tip is too low", "effectiveTip", effectiveTip.String())
+					log.Warn("effective tip is too low", "effectiveTip", effectiveTip.String())
 					// don't throw an error but we should avoid streaming this bid
 					continue
 				}

--- a/grpc/optimistic/server.go
+++ b/grpc/optimistic/server.go
@@ -41,6 +41,7 @@ var (
 	executeOptimisticBlockSuccessCount = metrics.GetOrRegisterCounter("astria/optimistic/execute_optimistic_block_success", nil)
 	optimisticBlockHeight              = metrics.GetOrRegisterGauge("astria/execution/optimistic_block_height", nil)
 	txsStreamedCount                   = metrics.GetOrRegisterCounter("astria/optimistic/txs_streamed", nil)
+	txsTipTooLow                       = metrics.GetOrRegisterCounter("astria/optimistic/txs_tip_too_low", nil)
 
 	executionOptimisticBlockTimer = metrics.GetOrRegisterTimer("astria/optimistic/execute_optimistic_block_time", nil)
 )
@@ -75,7 +76,8 @@ func (o *AuctionServiceV1Alpha1) GetBidStream(_ *auctionPb.GetBidStreamRequest, 
 				totalCost := big.NewInt(0)
 				effectiveTip, err := pendingTx.EffectiveGasTip(optimisticBlock.BaseFee)
 				if err != nil {
-					log.Warn("effective tip is too low", "effectiveTip", effectiveTip.String())
+					txsTipTooLow.Inc(1)
+					log.Debug("effective tip is too low", "effectiveTip", effectiveTip.String())
 					// don't throw an error but we should avoid streaming this bid
 					continue
 				}

--- a/grpc/optimistic/server.go
+++ b/grpc/optimistic/server.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
-	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth"
@@ -74,7 +73,11 @@ func (o *AuctionServiceV1Alpha1) GetBidStream(_ *auctionPb.GetBidStreamRequest, 
 				bid := auctionPb.Bid{}
 
 				totalCost := big.NewInt(0)
-				effectiveTip := cmath.BigMin(pendingTx.GasTipCap(), new(big.Int).Sub(pendingTx.GasFeeCap(), optimisticBlock.BaseFee))
+				effectiveTip, err := pendingTx.EffectiveGasTip(optimisticBlock.BaseFee)
+				if err != nil {
+					log.Error("effective tip is too low", "effectiveTip", effectiveTip.String())
+					continue
+				}
 				totalCost = totalCost.Mul(effectiveTip, big.NewInt(int64(pendingTx.Gas())))
 
 				marshalledTxs := [][]byte{}

--- a/grpc/optimistic/server.go
+++ b/grpc/optimistic/server.go
@@ -76,6 +76,7 @@ func (o *AuctionServiceV1Alpha1) GetBidStream(_ *auctionPb.GetBidStreamRequest, 
 				effectiveTip, err := pendingTx.EffectiveGasTip(optimisticBlock.BaseFee)
 				if err != nil {
 					log.Error("effective tip is too low", "effectiveTip", effectiveTip.String())
+					// don't throw an error but we should avoid streaming this bid
 					continue
 				}
 				totalCost = totalCost.Mul(effectiveTip, big.NewInt(int64(pendingTx.Gas())))


### PR DESCRIPTION
It is better to use the in-build `EffectiveGasTip` method to calculate the tip of a given tx. If the gas fee tip is too low, then we don't stream the bid to the auctioneer.

This has been tested by deploying auctioneer setup locally and sending txs against it.